### PR TITLE
Fix gem name

### DIFF
--- a/.github/pull_request_template.yml
+++ b/.github/pull_request_template.yml
@@ -4,6 +4,6 @@
 
 ## Checks
 
-- [ ] Have you followed the guidelines in our [Contributing section](https://github.com/arkimedes-dev/you-ruby?tab=readme-ov-file#contributing)?
+- [ ] Have you followed the guidelines in our [Contributing section](https://github.com/arkimedes-dev/ruby-you?tab=readme-ov-file#contributing)?
 - [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
 - [ ] Have you added an explanation of what your changes do and why you'd like us to include them?

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,5 +36,5 @@ jobs:
         uses: codecov/codecov-action@v4.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: arkimedes-dev/you-ruby
+          slug: arkimedes-dev/ruby-you
           file: coverage/coverage.xml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    you-ruby (0.1.0)
+    ruby-you (0.1.0)
       faraday (~> 2.0)
       faraday-retry (~> 2)
 
@@ -141,7 +141,7 @@ DEPENDENCIES
   standard (~> 1.36)
   timecop
   webmock (~> 3.17)
-  you-ruby!
+  ruby-you!
 
 BUNDLED WITH
    2.5.16

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# you-ruby
+# ruby-you
 
 A Ruby client for interacting with the You.com API, including the Smart, Research, Search, and News endpoints. This gem provides a simple and consistent interface, along with configurable retry logic, rate-limit handling, debugging options, and comprehensive error handling.
 
@@ -18,7 +18,7 @@ A Ruby client for interacting with the You.com API, including the Smart, Researc
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'you-ruby', path: 'path/to/you-ruby'
+gem 'ruby-you', path: 'path/to/ruby-you'
 ```
 
 Then execute
@@ -30,8 +30,8 @@ bundle install
 Or install it yourself as:
 
 ```bash
-gem build you-ruby.gemspec
-gem install you-ruby-0.1.0.gem
+gem build ruby-you.gemspec
+gem install ruby-you-0.1.0.gem
 ```
 
 ## Configuration

--- a/you-ruby.gemspec
+++ b/you-ruby.gemspec
@@ -1,15 +1,15 @@
 Gem::Specification.new do |spec|
-  spec.name = "you-ruby"
+  spec.name = "ruby-you"
   spec.version = "0.1.0"
   spec.authors = ["Martin Mochetti"]
   spec.summary = "A Ruby client for the You.com API."
   spec.description = "Provides a simple Ruby interface for interacting with the You.com Smart, Research, Search, and News endpoints."
-  spec.homepage = "https://github.com/arkimedes-dev/you-ruby"
+  spec.homepage = "https://github.com/arkimedes-dev/ruby-you"
   spec.license = "MIT"
 
   spec.required_ruby_version = ">= 2.6"
 
-  spec.files = Dir["{lib}/**/*", "README.md", "LICENSE", "you-ruby.gemspec"]
+  spec.files = Dir["{lib}/**/*", "README.md", "LICENSE", "ruby-you.gemspec"]
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "~> 2.0"
@@ -19,5 +19,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~> 3.17"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/yourusername/you-ruby"
+  spec.metadata["source_code_uri"] = "https://github.com/arkimedes-dev/ruby-you"
 end


### PR DESCRIPTION
## Description

Changes gem name from you-ruby to ruby-uou

## Checks

- [x] Have you followed the guidelines in our [Contributing section](https://github.com/arkimedes-dev/you-ruby?tab=readme-ov-file#contributing)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
